### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/docker-img-push.yaml
+++ b/.github/workflows/docker-img-push.yaml
@@ -1,4 +1,8 @@
 name: Build and Push Docker Image
+permissions:
+  contents: read
+  packages: write
+  actions: write
 on:
   push:
     branches:


### PR DESCRIPTION
Potential fix for [https://github.com/gvatsal60/Custom-WSL-OS/security/code-scanning/2](https://github.com/gvatsal60/Custom-WSL-OS/security/code-scanning/2)

To fix the issue, add a `permissions` block at the root of the workflow file. This block will explicitly define the minimal permissions required for the workflow to function correctly. Based on the actions used in the workflow, the following permissions are needed:
- `contents: read` for accessing the repository's contents.
- `packages: write` for pushing Docker images to the GitHub Container Registry.
- `actions: write` for creating and managing releases.

The `permissions` block should be added at the top level of the workflow, just below the `name` field.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
